### PR TITLE
[WB-17]: Update all CI CD jobs to use newest checkout action

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3.0.2
 
     - name: Cache maven dependencies
       uses: actions/cache@v2

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Latest Commit
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3.0.2
 
     - name: Check deps
       uses: nnichols/leiningen-dependency-update-action@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.WALL_BREW_BOT_PAT }}
@@ -21,9 +21,11 @@ jobs:
 
       - name: Format Clojure code
         run: |
-          cljstyle fix --report --report-timing $(find . -regextype posix-extended -regex '.*\.clj[csx]?$')
+          cljstyle fix --report --report-timing --verbose
+          git status
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:
           commit_message: |
             [Format] Auto-formatting

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
 
@@ -24,16 +24,13 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install clj-kondo
-        uses: DeLaGuardo/setup-clj-kondo@master
-        with:
-          version: '2021.06.01'
-
       - name: Lint Clojure
-        run: |
-          clj-kondo --fail-level error --config ./dev/lint/clj-kondo.edn --lint \
-            $(find . -type f -regex ".*\.clj[csx]?$")
+        uses: nnichols/clojure-lint-action@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          filter_mode: file


### PR DESCRIPTION
# Proposed Changes

- Additions:
- Updates: Use `actions/checkout@v3.0.2` to fix breaking git CLI change
- Deletions:
